### PR TITLE
Basic miner strategy

### DIFF
--- a/src/main/java/zasshu/Miner.java
+++ b/src/main/java/zasshu/Miner.java
@@ -59,7 +59,7 @@ public final class Miner extends AbstractRobot {
         mineCounter = 0;
       } else {
         controller.mine();
-        mineCounter++;
+        ++mineCounter;
       }
     }
   }


### PR DESCRIPTION
3:1 mine to move ratio.  If miner choose an invalid place to move, it just mines instead.
