### PR TITLE
Transfer supply network

### DIFF
--- a/src/main/java/zasshu/Barracks.java
+++ b/src/main/java/zasshu/Barracks.java
@@ -9,6 +9,8 @@ import zasshu.core.AbstractRobot;
 import zasshu.core.Controller;
 
 import battlecode.common.Direction;
+import battlecode.common.GameConstants;
+import battlecode.common.RobotInfo;
 import battlecode.common.RobotType;
 
 public final class Barracks extends AbstractRobot {
@@ -21,6 +23,16 @@ public final class Barracks extends AbstractRobot {
     if (controller.isCoreReady()) {
       Direction dir = getEnemyHQDirection();
       controller.spawn(dir, RobotType.SOLDIER);
+    }
+
+    RobotInfo[] robots = controller.getNearbyRobots(
+        GameConstants.SUPPLY_TRANSFER_RADIUS_SQUARED,
+        controller.getTeam());
+    for (int i = robots.length; --i >= 0;) {
+      int supplyUpkeep = robots[i].type.supplyUpkeep;
+      if (robots[i].supplyLevel < 5 * supplyUpkeep) {
+        controller.transferSupplies(50 * supplyUpkeep, robots[i]);
+      }
     }
   }
 }

--- a/src/main/java/zasshu/HQ.java
+++ b/src/main/java/zasshu/HQ.java
@@ -8,6 +8,8 @@ package zasshu;
 import zasshu.core.AbstractRobot;
 import zasshu.core.Controller;
 
+import battlecode.common.Clock;
+import battlecode.common.GameConstants;
 import battlecode.common.RobotInfo;
 import battlecode.common.RobotType;
 
@@ -78,6 +80,18 @@ public final class HQ extends AbstractRobot {
       }
     }
 
-    // TODO: Transfer supply
+    if (Clock.getRoundNum() % 50 == 0) {
+      RobotInfo[] robots = controller.getNearbyRobots(
+          GameConstants.SUPPLY_TRANSFER_RADIUS_SQUARED,
+          controller.getTeam());
+      for (int i = robots.length; --i >= 0;) {
+        if (robots[i].type.canBuild()) {
+          controller.transferSupplies(1500, robots[i]);
+        } else if (robots[i].type == RobotType.BEAVER) {
+          controller.transferSupplies(
+              50 * robots[i].type.supplyUpkeep, robots[i]);
+        }
+      }
+    }
   }
 }

--- a/src/main/java/zasshu/MinerFactory.java
+++ b/src/main/java/zasshu/MinerFactory.java
@@ -9,6 +9,7 @@ import zasshu.core.AbstractRobot;
 import zasshu.core.Controller;
 
 import battlecode.common.Direction;
+import battlecode.common.GameConstants;
 import battlecode.common.RobotInfo;
 import battlecode.common.RobotType;
 
@@ -38,6 +39,16 @@ public final class MinerFactory extends AbstractRobot {
 
       if (numMiners < NUM_MINER_TARGET) {
         controller.spawn(getEnemyHQDirection(), RobotType.MINER);
+      }
+    }
+
+    RobotInfo[] robots = controller.getNearbyRobots(
+        GameConstants.SUPPLY_TRANSFER_RADIUS_SQUARED,
+        controller.getTeam());
+    for (int i = robots.length; --i >= 0;) {
+      int supplyUpkeep = robots[i].type.supplyUpkeep;
+      if (robots[i].supplyLevel < 5 * supplyUpkeep) {
+        controller.transferSupplies(50 * supplyUpkeep, robots[i]);
       }
     }
   }


### PR DESCRIPTION
Here's my first shot at dealing with supply:

**HQ**

Every 50 turns, the HQ transfers 1500 supply to each production building in its transfer range, or however much it has left. Given that the HQ generates 10,000 supply every 50 turns, this should be enough to supply 6 buildings.

**Production Buildings**

Since they don't consume many byte codes, they will scan for allies in their supply range. If a unit is within 10 turns of hitting its upkeep, the building will transfer 50 turn's worth of supply to the unit, or however much it has left.
