### PR TITLE
Reduce bytecode usage for beaver attendance

### DIFF
--- a/src/main/java/zasshu/Beaver.java
+++ b/src/main/java/zasshu/Beaver.java
@@ -6,6 +6,7 @@
 package zasshu;
 
 import zasshu.core.AbstractRobot;
+import zasshu.core.Channels;
 import zasshu.core.Controller;
 
 import battlecode.common.DependencyProgress;
@@ -53,6 +54,9 @@ public final class Beaver extends AbstractRobot {
     if (pastLocations[head] != myLoc) {
       pastLocations[head++] = myLoc;
     }
+    int numBeavers = controller.readBroadcast(Channels.NUM_BEAVERS);
+    controller.broadcast(Channels.NUM_BEAVERS, numBeavers + 1);
+
     if (controller.isCoreReady()) {
       // TODO: If enemies are close, flee from danger.
       if (!isMovingToBuild) {

--- a/src/main/java/zasshu/HQ.java
+++ b/src/main/java/zasshu/HQ.java
@@ -6,6 +6,7 @@
 package zasshu;
 
 import zasshu.core.AbstractRobot;
+import zasshu.core.Channels;
 import zasshu.core.Controller;
 
 import battlecode.common.Clock;
@@ -64,20 +65,12 @@ public final class HQ extends AbstractRobot {
     }
 
     if (controller.isCoreReady()) {
-      RobotInfo[] robots = controller.getNearbyRobots();
-
       // Check for the number of beavers on the map that we own.
-      int numBeavers = 0;
-      for (int i = robots.length; --i >= 0;) {
-        if (robots[i].type == RobotType.BEAVER
-            && robots[i].team == controller.getTeam()) {
-          ++numBeavers;
-        }
-      }
-
+      int numBeavers = controller.readBroadcast(Channels.NUM_BEAVERS);
       if (numBeavers < NUM_BEAVER_TARGET) {
         controller.spawn(getEnemyHQDirection(), RobotType.BEAVER);
       }
+      controller.broadcast(Channels.NUM_BEAVERS, 0);
     }
 
     if (Clock.getRoundNum() % 50 == 0) {

--- a/src/main/java/zasshu/core/Channels.java
+++ b/src/main/java/zasshu/core/Channels.java
@@ -1,0 +1,19 @@
+/*
+ * MIT Battlecode 2015
+ * Copyright © 2014-2015 Holman Gao, Yang Yang. All Rights Reserved.
+ */
+
+package zasshu.core;
+
+/**
+ * A class of channel constants.
+ *
+ * @author Yang Yang
+ */
+public class Channels {
+
+  public static final int NUM_BEAVERS = 100;
+
+  private Channels() {
+  }
+}

--- a/src/main/java/zasshu/core/Controller.java
+++ b/src/main/java/zasshu/core/Controller.java
@@ -171,6 +171,21 @@ public final class Controller {
   }
 
   /**
+   * Returns the value stored on the specified channel.
+   *
+   * @param channel channel number
+   * @return value on channel
+   */
+  public int readBroadcast(int channel) {
+    try {
+      return rc.readBroadcast(channel);
+    } catch (GameActionException e) {
+      e.printStackTrace();
+    }
+    return 0;
+  }
+
+  /**
    * Whether or not this robot can perform a core action.
    *
    * @return {@code true} if robot can perform a core action
@@ -331,6 +346,23 @@ public final class Controller {
    */
   public RobotType getType() {
     return rc.getType();
+  }
+
+  /**
+   * Broadcasts the value {@code data} to the specific channel.
+   *
+   * @param channel channel number
+   * @param data value to broadcast
+   * @return {@code true} if broadcast was successful
+   */
+  public boolean broadcast(int channel, int data) {
+    try {
+      rc.broadcast(channel, data);
+      return true;
+    } catch (GameActionException e) {
+      e.printStackTrace();
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
Instead of calling senseNearbyRobot and looping over its return values, the HQ now gets the beaver count from a channel. Each beaver increments the counter and the HQ resets it at the start of each round.

I anticipate we will be using channels for other things as well, so the `Channels` class can be a place to store all constants.
