### PR TITLE
Propogate supply

### DIFF
--- a/src/main/java/zasshu/Barracks.java
+++ b/src/main/java/zasshu/Barracks.java
@@ -25,17 +25,5 @@ public final class Barracks extends AbstractRobot {
       Direction dir = getEnemyHQDirection();
       controller.spawn(dir, RobotType.SOLDIER);
     }
-    RobotInfo[] robots = controller.getNearbyRobots(
-        GameConstants.SUPPLY_TRANSFER_RADIUS_SQUARED,
-        controller.getTeam());
-    for (int i = robots.length; --i >= 0;) {
-      if (Clock.getBytecodesLeft() < 600) {
-        break;
-      }
-      int supplyUpkeep = robots[i].type.supplyUpkeep;
-      if (robots[i].supplyLevel < 5 * supplyUpkeep) {
-        controller.transferSupplies(100 * supplyUpkeep, robots[i]);
-      }
-    }
   }
 }

--- a/src/main/java/zasshu/Beaver.java
+++ b/src/main/java/zasshu/Beaver.java
@@ -85,6 +85,7 @@ public final class Beaver extends AbstractRobot {
         }
       }
     }
+    propogateSupply();
   }
 
   private Direction computeGradient() {

--- a/src/main/java/zasshu/Drone.java
+++ b/src/main/java/zasshu/Drone.java
@@ -111,6 +111,7 @@ public final class Drone extends AbstractRobot {
     }
     // TODO: Add a retreat strategy that moves according to influence gradient.
     // Gradient should be the direction of retreat.
+    propogateSupply();
   }
 
   private double computeForce(MapLocation loc, RobotInfo robot) {

--- a/src/main/java/zasshu/HQ.java
+++ b/src/main/java/zasshu/HQ.java
@@ -43,7 +43,6 @@ public final class HQ extends AbstractRobot {
     super(controller);
   }
 
-
   @Override protected void runHelper() {
     if (controller.isWeaponReady()) {
       RobotInfo[] enemies = controller.getNearbyRobots(
@@ -53,9 +52,6 @@ public final class HQ extends AbstractRobot {
       int maxPriority = AttackPriority.COMPUTER.ordinal();
 
       for (int i = enemies.length; --i >= 0;) {
-        // Calling Enum.valueOf is potentially dangerous here - if the enemy
-        // RobotType.toString conversion does not match an AttackPriority enum,
-        // the method will throw IllegalArgumentException.
         int p = AttackPriority.valueOf(enemies[i].type.toString()).ordinal();
         if (target == null || p < maxPriority
             || (p == maxPriority && enemies[i].health > target.health)) {
@@ -110,19 +106,6 @@ public final class HQ extends AbstractRobot {
       controller.broadcast(Channels.SHOULD_ATTACK_TARGET, attackTarget ? 1 : 0);
     }
 
-    // Keep this last in runHelper
-    if (Clock.getRoundNum() % 50 == 0) {
-      RobotInfo[] robots = controller.getNearbyRobots(
-          GameConstants.SUPPLY_TRANSFER_RADIUS_SQUARED,
-          controller.getTeam());
-      for (int i = robots.length; --i >= 0;) {
-        if (robots[i].type.canSpawn()) {
-          controller.transferSupplies(2000, robots[i]);
-        } else if (robots[i].type == RobotType.BEAVER) {
-          controller.transferSupplies(
-              50 * robots[i].type.supplyUpkeep, robots[i]);
-        }
-      }
-    }
+    propogateSupply();
   }
 }

--- a/src/main/java/zasshu/Helipad.java
+++ b/src/main/java/zasshu/Helipad.java
@@ -29,15 +29,5 @@ public final class Helipad extends AbstractRobot {
       Direction dir = getEnemyHQDirection();
       controller.spawn(dir, RobotType.DRONE);
     }
-
-    RobotInfo[] robots = controller.getNearbyRobots(
-        GameConstants.SUPPLY_TRANSFER_RADIUS_SQUARED,
-        controller.getTeam());
-    for (int i = robots.length; --i >= 0;) {
-      int supplyUpkeep = robots[i].type.supplyUpkeep;
-      if (robots[i].supplyLevel < 5 * supplyUpkeep) {
-        controller.transferSupplies(50 * supplyUpkeep, robots[i]);
-      }
-    }
   }
 }

--- a/src/main/java/zasshu/Miner.java
+++ b/src/main/java/zasshu/Miner.java
@@ -66,5 +66,6 @@ public final class Miner extends AbstractRobot {
         ++mineCounter;
       }
     }
+    propogateSupply();
   }
 }

--- a/src/main/java/zasshu/MinerFactory.java
+++ b/src/main/java/zasshu/MinerFactory.java
@@ -42,18 +42,5 @@ public final class MinerFactory extends AbstractRobot {
         controller.spawn(getEnemyHQDirection(), RobotType.MINER);
       }
     }
-
-    RobotInfo[] robots = controller.getNearbyRobots(
-        GameConstants.SUPPLY_TRANSFER_RADIUS_SQUARED,
-        controller.getTeam());
-    for (int i = robots.length; --i >= 0;) {
-      if (Clock.getBytecodesLeft() < 600) {
-        break;
-      }
-      int supplyUpkeep = robots[i].type.supplyUpkeep;
-      if (robots[i].supplyLevel < 5 * supplyUpkeep) {
-        controller.transferSupplies(100 * supplyUpkeep, robots[i]);
-      }
-    }
   }
 }

--- a/src/main/java/zasshu/Soldier.java
+++ b/src/main/java/zasshu/Soldier.java
@@ -100,6 +100,7 @@ public final class Soldier extends AbstractRobot {
     }
     // TODO: Add a retreat strategy that moves according to influence gradient.
     // Gradient should be the direction of retreat.
+    propogateSupply();
   }
 
   private double computeForce(MapLocation loc, RobotInfo robot) {

--- a/src/main/java/zasshu/core/AbstractRobot.java
+++ b/src/main/java/zasshu/core/AbstractRobot.java
@@ -8,7 +8,9 @@ package zasshu.core;
 import zasshu.util.Timer;
 
 import battlecode.common.Direction;
+import battlecode.common.GameConstants;
 import battlecode.common.MapLocation;
+import battlecode.common.RobotInfo;
 
 /**
  * Abstract skeletal implementation of the {@code Robot} interface.
@@ -56,5 +58,34 @@ public abstract class AbstractRobot implements Robot {
    */
   protected MapLocation getLocation() {
     return controller.getLocation();
+  }
+
+  /**
+   * Transfers supply to the robot with lowest supply, if our supply level is
+   * above the average supply level.
+   *
+   * @param robots list of robots to consider supplying
+   */
+  protected void propogateSupply() {
+    RobotInfo[] robots = controller.getNearbyRobots(
+        GameConstants.SUPPLY_TRANSFER_RADIUS_SQUARED, controller.getTeam());
+
+    double mySupply = controller.getSupplyLevel();
+    RobotInfo target = null;
+    double maxDifference = 0;
+    double totalSupply = 0;
+
+    for (int i = robots.length; --i >= 0;) {
+      totalSupply += robots[i].supplyLevel;
+      double supplyDifference = mySupply - robots[i].supplyLevel;
+      if (supplyDifference > maxDifference) {
+        maxDifference = supplyDifference;
+        target = robots[i];
+      }
+    }
+    double avgSupply = totalSupply / robots.length;
+    if (mySupply > avgSupply) {
+      controller.transferSupplies((int) (mySupply - avgSupply), target);
+    }
   }
 }

--- a/src/main/java/zasshu/core/Controller.java
+++ b/src/main/java/zasshu/core/Controller.java
@@ -157,6 +157,15 @@ public final class Controller {
   }
 
   /**
+   * Returns the amount of supply this robot has.
+   *
+   * @return amount of supply this robot has
+   */
+  public double getSupplyLevel() {
+    return rc.getSupplyLevel();
+  }
+
+  /**
    * Returns {@code true} if the specified location is occupied by another
    * robot.
    *
@@ -323,8 +332,10 @@ public final class Controller {
     if (getLocation().distanceSquaredTo(robot.location)
         <= GameConstants.SUPPLY_TRANSFER_RADIUS_SQUARED) {
       try {
-        rc.transferSupplies(supply, robot.location);
-        return true;
+        if (rc.getSupplyLevel() >= supply) {
+          rc.transferSupplies(supply, robot.location);
+          return true;
+        }
       } catch (GameActionException e) {
         e.printStackTrace();
       }


### PR DESCRIPTION
I tested out the proposed strategy we had discussed and it sucked. I came up with this instead:

Every turn, a robot will compute the average supply amongst all robots within supply range. If a robot is higher than the average, it will transfer the difference between its supply level and the average to the robot with the least amount of supply.

Empirically, this seems to do well - no robot was ever supply blocked when I ran simulations on ONE TOWER.
