### PR TITLE
Attack strategy change

### DIFF
--- a/src/main/java/zasshu/Drone.java
+++ b/src/main/java/zasshu/Drone.java
@@ -73,10 +73,9 @@ public final class Drone extends AbstractRobot {
       double maxPotential = Double.NEGATIVE_INFINITY;
       Direction maxDir = Direction.NONE;
 
-      MapLocation[] towers = controller.getEnemyTowerLocations();
-      MapLocation target = new MapLocation(
-          controller.readBroadcast(Channels.ATTACK_TARGET_X),
-          controller.readBroadcast(Channels.ATTACK_TARGET_Y));
+      MapLocation[] targets = getAttackTargets();
+      MapLocation target =
+          targets[controller.readBroadcast(Channels.ATTACK_TARGET_INDEX)];
 
       RobotInfo[] enemies = controller.getNearbyRobots(
           ROBOT_TYPE.sensorRadiusSquared,

--- a/src/main/java/zasshu/HQ.java
+++ b/src/main/java/zasshu/HQ.java
@@ -82,38 +82,34 @@ public final class HQ extends AbstractRobot {
 
     MapLocation[] enemyTowers = controller.getEnemyTowerLocations();
     MapLocation target;
+    int targetIndex = 0;
     if (enemyTowers.length > 0) {
       MapLocation myLoc = controller.getLocation();
       double closestDistance = Double.POSITIVE_INFINITY;
-      int closestIndex = 0;
       for (int i = enemyTowers.length; --i >= 0;) {
         double distance = myLoc.distanceSquaredTo(enemyTowers[i]);
         if (distance < closestDistance) {
           closestDistance = distance;
-          closestIndex = i;
+          targetIndex = i + 1;
         }
       }
-
-      target = enemyTowers[closestIndex];
+      target = enemyTowers[targetIndex - 1];
     } else {
       target = controller.getEnemyHQLocation();
     }
 
-    int existingTargetX = controller.readBroadcast(Channels.ATTACK_TARGET_X);
-    if (target.x != existingTargetX) {
-      controller.broadcast(Channels.ATTACK_TARGET_X, target.x);
-    }
-    int existingTargetY = controller.readBroadcast(Channels.ATTACK_TARGET_Y);
-    if (target.y != existingTargetY) {
-      controller.broadcast(Channels.ATTACK_TARGET_Y, target.y);
+    int existingTargetIndex =
+        controller.readBroadcast(Channels.ATTACK_TARGET_INDEX);
+    if (existingTargetIndex != targetIndex) {
+      controller.broadcast(Channels.ATTACK_TARGET_INDEX, targetIndex);
     }
 
     RobotInfo[] teammatesAroundTarget = controller.getNearbyRobots(
         target,
-        SWARM_RADIUS_SQUARED + 5,
+        SWARM_RADIUS_SQUARED + 10,
         controller.getTeam());
 
-    if (teammatesAroundTarget.length >= 10) {
+    if (teammatesAroundTarget.length >= 12) {
       attackDistance = 0;
     } else if (teammatesAroundTarget.length < 5) {
       attackDistance = SWARM_RADIUS_SQUARED;

--- a/src/main/java/zasshu/Soldier.java
+++ b/src/main/java/zasshu/Soldier.java
@@ -62,10 +62,8 @@ public final class Soldier extends AbstractRobot {
       double maxPotential = Double.NEGATIVE_INFINITY;
       Direction maxDir = Direction.NONE;
 
-      MapLocation[] towers = controller.getEnemyTowerLocations();
-      MapLocation target = new MapLocation(
-          controller.readBroadcast(Channels.ATTACK_TARGET_X),
-          controller.readBroadcast(Channels.ATTACK_TARGET_Y));
+      MapLocation[] targets = getAttackTargets();
+      int targetIndex = controller.readBroadcast(Channels.ATTACK_TARGET_INDEX);
 
       RobotInfo[] enemies = controller.getNearbyRobots(
           ROBOT_TYPE.sensorRadiusSquared,
@@ -76,10 +74,26 @@ public final class Soldier extends AbstractRobot {
       for (int i = 8; --i >= 0;) {
         Direction dir = myLoc.directionTo(locs[i]);
         if (controller.canMove(dir)) {
-          int distanceToTarget = locs[i].distanceSquaredTo(target);
-          double potential = 10 * computePositiveForce(distanceToTarget);
+          double potential = 0.0;
+          boolean badDir = false;
 
-          if (distanceToTarget <= attackDistance) {
+          for (int j = targets.length; --j >= 0;) {
+            MapLocation possibleTarget = targets[j];
+            int distanceToTarget = locs[i].distanceSquaredTo(possibleTarget);
+
+            if (j == targetIndex) {
+              potential += 10 * computePositiveForce(distanceToTarget);
+
+              if (distanceToTarget <= attackDistance) {
+                badDir = true;
+                break;
+              }
+            } else if (distanceToTarget <= 24) {
+              badDir = true;
+              break;
+            }
+          }
+          if (badDir) {
             continue;
           }
 

--- a/src/main/java/zasshu/core/AbstractRobot.java
+++ b/src/main/java/zasshu/core/AbstractRobot.java
@@ -88,4 +88,15 @@ public abstract class AbstractRobot implements Robot {
       controller.transferSupplies((int) (mySupply - avgSupply), target);
     }
   }
+
+  protected MapLocation[] getAttackTargets() {
+    MapLocation hq = controller.getEnemyHQLocation();
+    MapLocation[] towers = controller.getEnemyTowerLocations();
+
+    MapLocation[] targets = new MapLocation[towers.length + 1];
+    targets[0] = hq;
+    System.arraycopy(towers, 0, targets, 1, towers.length);
+
+    return targets;
+  }
 }

--- a/src/main/java/zasshu/core/Channels.java
+++ b/src/main/java/zasshu/core/Channels.java
@@ -13,8 +13,14 @@ package zasshu.core;
 public class Channels {
 
   public static final int NUM_BEAVERS = 100;
-  public static final int ATTACK_TARGET_X = 200;
-  public static final int ATTACK_TARGET_Y = 201;
+
+  /*
+   * This is either:
+   * - 0 signifying to attack HQ
+   * - index of tower starting at 1, so 1 => tower[0]
+   */
+  public static final int ATTACK_TARGET_INDEX = 200;
+
   public static final int ATTACK_DISTANCE = 202;
 
   private Channels() {


### PR DESCRIPTION
Things going on:
- Soldiers need to find HQ and Tower locations, to make sure they dont go into paths of these targets
- Because Soldiers are using all locations, we just broadcast the target index in this array rather than a location
- in the movement loop, we iterate through all of the targets to make sure we dont go into range of any, unless its the one we are trying to attack
