### PR TITLE
Compute and cache dangerous locations for Miners

### DIFF
--- a/src/main/java/team164/Miner.java
+++ b/src/main/java/team164/Miner.java
@@ -9,6 +9,7 @@ import static team164.util.Algorithms.*;
 
 import team164.core.AbstractRobot;
 import team164.core.Controller;
+import team164.util.MapLocationSet;
 
 import battlecode.common.Direction;
 import battlecode.common.MapLocation;
@@ -20,6 +21,20 @@ import java.util.Random;
 /**
  * A Miner robot.
  *
+ * <p>A Miner attempts to maximize mining efficiency by staying on a square with
+ * more than 10 ore, since mining rate is capped at 2.5. If the current map
+ * location contains less than 10 ore, it moves to an adjacent location with
+ * more ore. If no such location exists, it continues to mine at its current
+ * location.
+ *
+ * <p>If a map location and its surroundings contains no ore, the Miner will
+ * move in a random direction, never visiting a map location that it previously
+ * visited in the past 5 turns.
+ *
+ * <p>Finally, a Miner prioritizes its own life over all other functions. If an
+ * enemy is within sensor radius, the Miner flees by moving in the opposite
+ * direction.
+ *
  * @author Holman Gao
  * @author Yang Yang
  */
@@ -28,22 +43,43 @@ public final class Miner extends AbstractRobot {
   private final Random rnd = new Random();
 
   /**
-   * Constructs a {@code Miner} object.
+   * A set of map locations that are within attack range of enemy towers. The
+   * Miner is forbidden from mining in these locations.
+   */
+  private final MapLocationSet dangerousLocations = new MapLocationSet();
+
+  private MapLocation myLoc;
+  private MapLocation[] adjacentSquares;
+
+  /**
+   * Constructs a {@code Miner} robot.
+   *
+   * <p>The Miner's RNG is seeded with the robot's ID.
    *
    * @param c controller
    */
   public Miner(Controller c) {
     super(c);
     rnd.setSeed(controller.getID());
+
+    // Add all map locations within enemy tower attack range into a set of
+    // dangerous locations.
+    MapLocation[] enemyTowers = controller.getEnemyTowerLocations();
+    for (int i = enemyTowers.length; --i >= 0;) {
+      MapLocation[] locs = MapLocation.getAllMapLocationsWithinRadiusSq(
+          enemyTowers[i], RobotType.TOWER.attackRadiusSquared);
+      for (int j = locs.length; --j >= 0;) {
+        dangerousLocations.add(locs[j]);
+      }
+    }
   }
 
   @Override protected void runHelper() {
     if (controller.isCoreReady()) {
-      MapLocation myLoc = getLocation();
+      myLoc = getLocation();
+      adjacentSquares = MapLocation.getAllMapLocationsWithinRadiusSq(myLoc, 2);
       RobotInfo[] enemies = controller.getNearbyRobots(
           RobotType.MINER.sensorRadiusSquared, controller.getOpponentTeam());
-      MapLocation[] locs = MapLocation.getAllMapLocationsWithinRadiusSq(
-          myLoc, 2);
       if (enemies.length > 0) {
         flee(enemies);
       } else {
@@ -57,18 +93,25 @@ public final class Miner extends AbstractRobot {
     }
   }
 
+  /**
+   * Moves the robot in the direction opposite of the enemy forces.
+   *
+   * <p>The direction chosen is the direction of minimal potential gradient,
+   * where enemies are positive charges.
+   *
+   * @param enemies enemy robots
+   */
   private void flee(RobotInfo[] enemies) {
-    MapLocation myLoc = getLocation();
-    MapLocation[] locs = MapLocation.getAllMapLocationsWithinRadiusSq(
-        myLoc, 2);
+    MapLocation[] locs = adjacentSquares;
     MapLocation target = null;
     double maxPotential = Double.NEGATIVE_INFINITY;
     for (int i = locs.length; --i >= 0;) {
-      if (controller.canMove(myLoc.directionTo(locs[i]))) {
+      if (controller.canMove(myLoc.directionTo(locs[i]))
+          && !dangerousLocations.contains(locs[i])) {
         double potential = 0;
         for (int j = enemies.length; --j >= 0;) {
           int d = locs[i].distanceSquaredTo(enemies[j].location);
-          potential -= 5.0 / d;
+          potential -= 1.0 / d;
         }
         if (potential > maxPotential) {
           maxPotential = potential;
@@ -79,27 +122,20 @@ public final class Miner extends AbstractRobot {
     controller.move(myLoc.directionTo(target));
   }
 
+  /**
+   * Moves in the direction of increasing ore. If no adjaacent square contains
+   * more ore and the current map location has ore, mine. Otherwise, move in a
+   * random direction.
+   *
+   * <p>All moves will be outside of enemy tower attack radius.
+   */
   private void move() {
-    MapLocation myLoc = getLocation();
-    MapLocation[] locs = MapLocation.getAllMapLocationsWithinRadiusSq(
-        myLoc, 2);
-    MapLocation[] enemyTowers = controller.getEnemyTowerLocations();
-
+    MapLocation[] locs = adjacentSquares;
     MapLocation target = null;
     double maxOre = controller.senseOre(myLoc);
     for (int i = locs.length; --i >= 0;) {
-      if (!controller.isLocationOccupied(locs[i])) {
-        boolean inTowerRange = false;
-        for (int j = enemyTowers.length; --j >= 0;) {
-          if (locs[i].distanceSquaredTo(enemyTowers[j])
-              <= RobotType.TOWER.attackRadiusSquared) {
-            inTowerRange = true;
-            break;
-          }
-        }
-        if (inTowerRange) {
-          continue;
-        }
+      if (!controller.isLocationOccupied(locs[i])
+          && !dangerousLocations.contains(locs[i])) {
         double ore = controller.senseOre(locs[i]);
         if (ore > maxOre) {
           maxOre = ore;
@@ -107,6 +143,7 @@ public final class Miner extends AbstractRobot {
         }
       }
     }
+
     if (target != null) {
       controller.move(myLoc.directionTo(target));
     } else if (maxOre > 0) {
@@ -116,18 +153,8 @@ public final class Miner extends AbstractRobot {
       boolean loop = true;
       while (loop) {
         int i = rnd.nextInt(8);
-        if (controller.canMove(dirs[i])) {
-          boolean inTowerRange = false;
-          for (int j = enemyTowers.length; --j >= 0;) {
-            if (locs[i].distanceSquaredTo(enemyTowers[j])
-                <= RobotType.TOWER.attackRadiusSquared) {
-              inTowerRange = true;
-              break;
-            }
-          }
-          if (inTowerRange) {
-            continue;
-          }
+        if (controller.canMove(dirs[i])
+            && !dangerousLocations.contains(myLoc.add(dirs[i]))) {
           controller.move(dirs[i]);
           loop = false;
         }


### PR DESCRIPTION
The pre computation takes around 40K byte codes (4 turns) with 6 towers (414 map locations). In return, the robots use about 800 less byte codes every turn that they require to move.

It would be nice to only add the squares in the outer radius of the towers but this can be a further optimization (Breseham's circle algorithm).
