### PR TITLE
Miners do attendance

### DIFF
--- a/src/main/java/team164/Miner.java
+++ b/src/main/java/team164/Miner.java
@@ -5,12 +5,14 @@
 
 package team164;
 
+import static team164.core.Channels.*;
 import static team164.util.Algorithms.*;
 
 import team164.core.AbstractRobot;
 import team164.core.Controller;
 import team164.util.MapLocationSet;
 
+import battlecode.common.Clock;
 import battlecode.common.Direction;
 import battlecode.common.MapLocation;
 import battlecode.common.RobotInfo;
@@ -81,6 +83,10 @@ public final class Miner extends AbstractRobot {
   }
 
   @Override protected void runHelper() {
+    if (Clock.getRoundNum() % RobotType.MINER.buildTurns == 0) {
+      int numMiners = controller.readBroadcast(NUM_MINERS);
+      controller.broadcast(NUM_MINERS, numMiners + 1);
+    }
     if (controller.isCoreReady()) {
       myLoc = getLocation();
       adjacentSquares = MapLocation.getAllMapLocationsWithinRadiusSq(myLoc, 2);

--- a/src/main/java/team164/MinerFactory.java
+++ b/src/main/java/team164/MinerFactory.java
@@ -5,6 +5,8 @@
 
 package team164;
 
+import static team164.core.Channels.*;
+
 import team164.core.AbstractRobot;
 import team164.core.Controller;
 
@@ -27,19 +29,11 @@ public final class MinerFactory extends AbstractRobot {
 
   @Override protected void runHelper() {
     if (controller.isCoreReady()) {
-      RobotInfo[] robots = controller.getNearbyRobots();
-
-      // Check for the number of miners on the map that we own.
-      int numMiners = 0;
-      for (int i = robots.length; --i >= 0;) {
-        if (robots[i].type == RobotType.MINER
-            && robots[i].team == controller.getTeam()) {
-          ++numMiners;
+      if (Clock.getRoundNum() % RobotType.MINER.buildTurns == 1) {
+        int numMiners = controller.readBroadcast(NUM_MINERS);
+        if (numMiners < NUM_MINER_TARGET) {
+          controller.spawn(getEnemyHQDirection(), RobotType.MINER);
         }
-      }
-
-      if (numMiners < NUM_MINER_TARGET) {
-        controller.spawn(getEnemyHQDirection(), RobotType.MINER);
       }
     }
   }

--- a/src/main/java/team164/core/Channels.java
+++ b/src/main/java/team164/core/Channels.java
@@ -13,6 +13,7 @@ package team164.core;
 public class Channels {
 
   public static final int NUM_BEAVERS = 100;
+  public static final int NUM_MINERS = 101;
 
   public static final int TARGET_LOCATION = 200;
   public static final int ATTACK_DISTANCE = 202;


### PR DESCRIPTION
Similar to Beavers, Miners now broadcast their existence once every `buildTurns` turns. On the next turn, the MinerFactory uses the number to determine whether or not to spawn Miners.

Fixes bug #128.
