### PR TITLE
Produce miners based on size of map

### DIFF
--- a/src/main/java/team164/MinerFactory.java
+++ b/src/main/java/team164/MinerFactory.java
@@ -52,6 +52,7 @@ public final class MinerFactory extends AbstractRobot {
         if (numMiners < numTargetMiners) {
           controller.spawn(getEnemyHQDirection(), RobotType.MINER);
         }
+        controller.broadcast(NUM_MINERS, 0);
       }
     }
   }


### PR DESCRIPTION
We now use the distance between HQs as a proxy for map size. The MinerFactory produces robots if it is less than the target number, which is defined by a logistic function currently with a horizontal asymptote at 30.

Fixes #144.
