### PR TITLE
Make all robot types broadcast their alive status

### DIFF
--- a/src/main/java/team164/Beaver.java
+++ b/src/main/java/team164/Beaver.java
@@ -5,13 +5,13 @@
 
 package team164;
 
+import static battlecode.common.RobotType.*;
 import static team164.util.Algorithms.*;
 
 import team164.core.AbstractRobot;
 import team164.core.Channels;
 import team164.core.Controller;
 
-import battlecode.common.Clock;
 import battlecode.common.DependencyProgress;
 import battlecode.common.Direction;
 import battlecode.common.MapLocation;
@@ -22,8 +22,7 @@ import battlecode.common.TerrainTile;
 public final class Beaver extends AbstractRobot {
 
   private static final RobotType[] BUILD_ORDER = new RobotType[] {
-    RobotType.MINERFACTORY, RobotType.BARRACKS, RobotType.TANKFACTORY,
-    RobotType.HELIPAD, RobotType.AEROSPACELAB, RobotType.SUPPLYDEPOT
+    MINERFACTORY, BARRACKS, TANKFACTORY, HELIPAD, AEROSPACELAB, SUPPLYDEPOT
   };
 
   private static final int[] BUILD_COUNT = new int[] {
@@ -75,9 +74,6 @@ public final class Beaver extends AbstractRobot {
   }
 
   @Override protected void runHelper() {
-    if (Clock.getRoundNum() % RobotType.BEAVER.buildTurns == 0) {
-      broadcastAlive();
-    }
     if (controller.isCoreReady()) {
       // TODO: If enemies are close, flee from danger.
       if (!isMovingToBuild) {
@@ -171,14 +167,6 @@ public final class Beaver extends AbstractRobot {
       }
     }
     return true;
-  }
-
-  /**
-   * Broadcast that we are allive by incrementing the beaver channel.
-   */
-  private void broadcastAlive() {
-    int numBeavers = controller.readBroadcast(Channels.NUM_BEAVERS);
-    controller.broadcast(Channels.NUM_BEAVERS, numBeavers + 1);
   }
 
   /**

--- a/src/main/java/team164/HQ.java
+++ b/src/main/java/team164/HQ.java
@@ -5,6 +5,8 @@
 
 package team164;
 
+import static battlecode.common.RobotType.*;
+import static team164.core.Channels.*;
 import static team164.util.Algorithms.*;
 
 import team164.core.AbstractRobot;
@@ -80,15 +82,14 @@ public final class HQ extends AbstractRobot {
 
     if (controller.isCoreReady()) {
       // Check for the number of beavers on the map that we own.
-      if (Clock.getRoundNum() % RobotType.BEAVER.buildTurns == 1) {
-        int numBeavers = controller.readBroadcast(Channels.NUM_BEAVERS);
+      if (Clock.getRoundNum() % BEAVER.buildTurns == 2) {
+        int numBeavers = controller.readBroadcast(getCountChannel(BEAVER));
         if (numBeavers < NUM_BEAVER_TARGET) {
-          controller.spawn(getEnemyHQDirection(), RobotType.BEAVER);
+          controller.spawn(getEnemyHQDirection(), BEAVER);
         }
-        controller.broadcast(Channels.NUM_BEAVERS, 0);
       }
     }
-
+    resetRobotCount();
     computeAttackTarget();
 
     RobotInfo[] teammatesAroundTarget = controller.getNearbyRobots(
@@ -142,5 +143,15 @@ public final class HQ extends AbstractRobot {
     }
     controller.broadcast(Channels.TARGET_LOCATION,
         locationToInt(currentTarget, controller.getLocation()));
+  }
+
+  private void resetRobotCount() {
+    int roundNum = Clock.getRoundNum();
+    RobotType[] types = RobotType.values();
+    for (int i = types.length; --i >= 0;) {
+      if (roundNum % types[i].buildTurns == 0) {
+        controller.broadcast(getCountChannel(types[i]), 0);
+      }
+    }
   }
 }

--- a/src/main/java/team164/Miner.java
+++ b/src/main/java/team164/Miner.java
@@ -12,7 +12,6 @@ import team164.core.AbstractRobot;
 import team164.core.Controller;
 import team164.util.MapLocationSet;
 
-import battlecode.common.Clock;
 import battlecode.common.Direction;
 import battlecode.common.MapLocation;
 import battlecode.common.RobotInfo;
@@ -83,10 +82,6 @@ public final class Miner extends AbstractRobot {
   }
 
   @Override protected void runHelper() {
-    if (Clock.getRoundNum() % RobotType.MINER.buildTurns == 0) {
-      int numMiners = controller.readBroadcast(NUM_MINERS);
-      controller.broadcast(NUM_MINERS, numMiners + 1);
-    }
     if (controller.isCoreReady()) {
       myLoc = getLocation();
       adjacentSquares = MapLocation.getAllMapLocationsWithinRadiusSq(myLoc, 2);

--- a/src/main/java/team164/MinerFactory.java
+++ b/src/main/java/team164/MinerFactory.java
@@ -5,6 +5,7 @@
 
 package team164;
 
+import static battlecode.common.RobotType.*;
 import static team164.core.Channels.*;
 
 import team164.core.AbstractRobot;
@@ -47,12 +48,12 @@ public final class MinerFactory extends AbstractRobot {
 
   @Override protected void runHelper() {
     if (controller.isCoreReady()) {
-      if (Clock.getRoundNum() % RobotType.MINER.buildTurns == 1) {
-        int numMiners = controller.readBroadcast(NUM_MINERS);
+      if (Clock.getRoundNum() % MINER.buildTurns == 1) {
+        int numMiners = controller.readBroadcast(getCountChannel(MINER));
         if (numMiners < numTargetMiners) {
-          controller.spawn(getEnemyHQDirection(), RobotType.MINER);
+          controller.spawn(getEnemyHQDirection(), MINER);
         }
-        controller.broadcast(NUM_MINERS, 0);
+        controller.broadcast(getCountChannel(MINER), 0);
       }
     }
   }

--- a/src/main/java/team164/core/AbstractRobot.java
+++ b/src/main/java/team164/core/AbstractRobot.java
@@ -5,14 +5,17 @@
 
 package team164.core;
 
+import static team164.core.Channels.*;
 import static team164.util.Algorithms.*;
 
 import team164.util.Timer;
 
+import battlecode.common.Clock;
 import battlecode.common.Direction;
 import battlecode.common.GameConstants;
 import battlecode.common.MapLocation;
 import battlecode.common.RobotInfo;
+import battlecode.common.RobotType;
 import battlecode.common.TerrainTile;
 
 /**
@@ -25,6 +28,7 @@ public abstract class AbstractRobot implements Robot {
 
   protected final Controller controller;
   protected final Timer timer;
+  protected final RobotType type;
 
   protected MapLocation target;
   protected MapLocation myLoc;
@@ -35,11 +39,15 @@ public abstract class AbstractRobot implements Robot {
   protected AbstractRobot(Controller ctrl) {
     controller = ctrl;
     timer = new Timer(controller.getType());
+    type = controller.getType();
   }
 
   @Override public void run() {
     while (true) {
       try {
+        if (Clock.getRoundNum() % type.buildTurns == 1) {
+          broadcastAlive();
+        }
         runHelper();
       } catch (Exception e) {
         e.printStackTrace();
@@ -146,5 +154,14 @@ public abstract class AbstractRobot implements Robot {
     // keep rotating until you find an open space (but dont factor in robots)
     // try to move there
     // observe Caterpies
+  }
+
+  /**
+   * Increments the attendance channel for this robot type by 1.
+   */
+  private void broadcastAlive() {
+    int channel = getCountChannel(controller.getType());
+    int count = controller.readBroadcast(channel);
+    controller.broadcast(channel, count + 1);
   }
 }

--- a/src/main/java/team164/core/Channels.java
+++ b/src/main/java/team164/core/Channels.java
@@ -5,6 +5,8 @@
 
 package team164.core;
 
+import battlecode.common.RobotType;
+
 /**
  * A class of channel constants.
  *
@@ -12,11 +14,25 @@ package team164.core;
  */
 public class Channels {
 
-  public static final int NUM_BEAVERS = 100;
-  public static final int NUM_MINERS = 101;
-
   public static final int TARGET_LOCATION = 200;
   public static final int ATTACK_DISTANCE = 202;
+
+  /**
+   * Start channel for attendance. Channel {@code ATTENDANCE +
+   * RobotType.ordinal()} is the number of allied robots of type {@code
+   * RobotType}.
+   */
+  private static final int ATTENDANCE_START = 100;
+
+  /**
+   * Returns the channel number for the attedance of the specified type.
+   *
+   * @param type robot type
+   * @return channel number
+   */
+  public static int getCountChannel(RobotType type) {
+    return ATTENDANCE_START + type.ordinal();
+  }
 
   private Channels() {
   }


### PR DESCRIPTION
On `Clock.getRoundNum() % buildTurns == 0`, the HQ resets the count.
On `Clock.getRoundNum() % buildTurns == 1`, the robots increment the count.

TODO:

On `Clock.getRoundNum() % buildTurns == 2`, the production buildings build if needed and decrement the count. 
