### PR TITLE
Bugfix for fleeing miner

### DIFF
--- a/src/main/java/team164/Miner.java
+++ b/src/main/java/team164/Miner.java
@@ -126,7 +126,9 @@ public final class Miner extends AbstractRobot {
         }
       }
     }
-    controller.move(myLoc.directionTo(target));
+    if (target != null) {
+      controller.move(myLoc.directionTo(target));
+    }
   }
 
   /**


### PR DESCRIPTION
When it is blocked by other robots, don't attempt to move.

Fixes #167.
