### PR TITLE
Build additional production structures when needed

### DIFF
--- a/src/main/java/team164/Beaver.java
+++ b/src/main/java/team164/Beaver.java
@@ -7,12 +7,13 @@ package team164;
 
 import static battlecode.common.DependencyProgress.*;
 import static battlecode.common.RobotType.*;
+import static team164.core.Channels.*;
 import static team164.util.Algorithms.*;
 
 import team164.core.AbstractRobot;
-import team164.core.Channels;
 import team164.core.Controller;
 
+import battlecode.common.Clock;
 import battlecode.common.Direction;
 import battlecode.common.MapLocation;
 import battlecode.common.RobotInfo;
@@ -159,6 +160,23 @@ public final class Beaver extends AbstractRobot {
           && controller.getDependencyProgress(type) == NONE) {
         buildType = type;
         break;
+      }
+    }
+
+    if (buildType == null) {
+      RobotType[] production = new RobotType[] {
+        BARRACKS, HELIPAD, TANKFACTORY, AEROSPACELAB
+      };
+      for (int i = production.length; --i >= 0;) {
+        RobotType type = production[i];
+        if (Clock.getRoundNum() % type.buildTurns > 2) {
+          int channel = getDebtChannel(type);
+          int debt = controller.readBroadcast(channel);
+          if (debt != 0) {
+            controller.broadcast(channel, 0);
+            return type;
+          }
+        }
       }
     }
     return buildType;

--- a/src/main/java/team164/MinerFactory.java
+++ b/src/main/java/team164/MinerFactory.java
@@ -48,7 +48,7 @@ public final class MinerFactory extends ProductionStructure {
 
   @Override protected boolean shouldSpawnUnit() {
     if (controller.isCoreReady()) {
-      if (Clock.getRoundNum() % MINER.buildTurns > 1) {
+      if (Clock.getRoundNum() % MINER.buildTurns == 2) {
         int numMiners = controller.readBroadcast(getCountChannel(MINER));
         if (numMiners < numTargetMiners) {
           return true;

--- a/src/main/java/team164/core/Channels.java
+++ b/src/main/java/team164/core/Channels.java
@@ -24,6 +24,8 @@ public class Channels {
    */
   private static final int ATTENDANCE_START = 100;
 
+  private static final int DEBT_START = 150;
+
   /**
    * Returns the channel number for the attedance of the specified type.
    *
@@ -32,6 +34,16 @@ public class Channels {
    */
   public static int getCountChannel(RobotType type) {
     return ATTENDANCE_START + type.ordinal();
+  }
+
+  /**
+   * Returns the channel number for the attedance of the specified type.
+   *
+   * @param type robot type
+   * @return channel number
+   */
+  public static int getDebtChannel(RobotType type) {
+    return DEBT_START + type.ordinal();
   }
 
   private Channels() {


### PR DESCRIPTION
If a production structure should build a unit but can't, it broadcasts to the channels. When a beaver is notified, it will build the needed structure.

I tested on drone map. Aerospace Labs get built as expected since they are the bottleneck. At round 1000ish, no more buildings get built as we are approaching mining rate bottleneck.
